### PR TITLE
Cannot find module 'rimraf'

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "chalk": "^1.1.0",
     "filesize": "^3.1.3",
     "lodash": "^4.3.0",
+    "rimraf": "^2.5.2",
     "symlink-or-copy": "^1.0.1",
     "walk": "^2.3.9"
   },


### PR DESCRIPTION
```
Error: Cannot find module 'rimraf'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
```
